### PR TITLE
Remove node 6 support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,0 @@
-{
-    "plugins": [
-        "transform-object-rest-spread",
-        "transform-regenerator"
-    ],
-    "presets": ["env"]
-}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,4 @@
 var gulp = require('gulp');
-var babel = require('gulp-babel');
 var eslint = require('gulp-eslint');
 
 var src = [
@@ -13,8 +12,4 @@ gulp.task('lint', function() {
         .pipe(eslint.failAfterError());
 });
 
-gulp.task('default', ['lint'], function() {
-    return gulp.src(src)
-        .pipe(babel())
-        .pipe(gulp.dest('lib'));
-});
+gulp.task('default', ['lint']);

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const launcher = require('./lib/karma-cbt-launcher');
-const reporter = require('./lib/reporter');
+const launcher = require('./src/karma-cbt-launcher');
+const reporter = require('./src/reporter');
 
 module.exports = { 
     'reporter:CrossBrowserTesting': ['type', reporter],

--- a/package.json
+++ b/package.json
@@ -21,15 +21,9 @@
     "selenium-webdriver": "^3.5.0"
   },
   "engines": {
-    "node": ">= 6.11.0"
+    "node": ">= 8"
   },
   "devDependencies": {
-    "babel": "^6.23.0",
-    "babel-core": "^6.26.3",
-    "babel-eslint": "^8.2.3",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-plugin-transform-regenerator": "^6.26.0",
-    "babel-preset-env": "^1.6.1",
     "eslint": "^4.19.1",
     "eslint-config-standard": "^11.0.0",
     "eslint-plugin-import": "^2.11.0",
@@ -37,7 +31,6 @@
     "eslint-plugin-promise": "^3.7.0",
     "eslint-plugin-standard": "^3.1.0",
     "gulp": "^3.9.1",
-    "gulp-babel": "^7.0.1",
     "gulp-eslint": "^4.0.2"
   }
 }


### PR DESCRIPTION
Hi!
babel generated sources are not compatible with more recent node version.
Since support for node 6 has ended, would you consider removing the support for this version and dropping babel?
Thanks